### PR TITLE
Add text to speech to word page and clip reader page

### DIFF
--- a/src/components/ClipReaderHeader.tsx
+++ b/src/components/ClipReaderHeader.tsx
@@ -7,6 +7,7 @@ import { MenuIcon } from "~/icons/MenuIcon";
 import { OpenInNewIcon } from "~/icons/OpenInNewIcon";
 import { RefreshIcon } from "~/icons/RefreshIcon";
 import { SearchIcon } from "~/icons/SearchIcon";
+import { VolumeUp } from "~/icons/VolumeUp";
 import { useClipReaderTextStore } from "~/stores/clipReaderTextStore";
 import { useDarkModeStore } from "~/stores/darkModeStore";
 import { useFlashcardStore } from "~/stores/flashcardStore";
@@ -14,6 +15,7 @@ import { type WordLookup } from "~/stores/historyStore";
 import { useStore } from "~/stores/useStore";
 import { classNames } from "~/utils/classNames";
 import { createWordLink } from "~/utils/createWordLink";
+import { textToSpeech } from "~/utils/textToSpeech";
 
 const UnselectedTextMenu = ({ openSideMenu }: { openSideMenu: () => void }) => {
   const addClipReaderText = useClipReaderTextStore((x) => x.addClipReaderText);
@@ -83,6 +85,14 @@ const SelectedTextMenu = ({
       >
         <span className="sr-only">Copy selected text</span>
         <ContentCopyIcon />
+      </button>
+
+      <button
+        className="flex h-full grow basis-1 items-center justify-center"
+        onClick={() => textToSpeech(wordLookup.wordEntry.word)}
+      >
+        <span className="sr-only">Play pronunciation</span>
+        <VolumeUp />
       </button>
 
       {wordEntryIsFlashcard ? (

--- a/src/components/WordHeader.tsx
+++ b/src/components/WordHeader.tsx
@@ -11,6 +11,8 @@ import { ChevronRightIcon } from "~/icons/ChevronRightIcon";
 import { type WordEntry } from "~/dictionary/search";
 import { createWordLink } from "~/utils/createWordLink";
 import { type WordLookup } from "~/stores/historyStore";
+import { textToSpeech } from "~/utils/textToSpeech";
+import { VolumeUp } from "~/icons/VolumeUp";
 
 export const WordHeader = ({
   wordLookup,
@@ -136,6 +138,12 @@ export const WordHeader = ({
                 pronunciation={wordLookup.wordEntry.pronunciation}
                 pitchAccents={wordLookup.wordEntry.pitchAccents}
               />
+              <button
+                onClick={() => textToSpeech(wordLookup.wordEntry.pronunciation)}
+              >
+                <span className="sr-only">Play pronunciation</span>
+                <VolumeUp />
+              </button>
             </div>
           </section>
         </div>

--- a/src/components/WordHeader.tsx
+++ b/src/components/WordHeader.tsx
@@ -138,9 +138,7 @@ export const WordHeader = ({
                 pronunciation={wordLookup.wordEntry.pronunciation}
                 pitchAccents={wordLookup.wordEntry.pitchAccents}
               />
-              <button
-                onClick={() => textToSpeech(wordLookup.wordEntry.pronunciation)}
-              >
+              <button onClick={() => textToSpeech(wordLookup.wordEntry.word)}>
                 <span className="sr-only">Play pronunciation</span>
                 <VolumeUp />
               </button>

--- a/src/icons/VolumeUp.tsx
+++ b/src/icons/VolumeUp.tsx
@@ -1,0 +1,15 @@
+export const VolumeUp = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 -960 960 960"
+      width="24"
+    >
+      <path
+        fill="currentColor"
+        d="M560-131v-82q90-26 145-100t55-168q0-94-55-168T560-749v-82q124 28 202 125.5T840-481q0 127-78 224.5T560-131ZM120-360v-240h160l200-200v640L280-360H120Zm440 40v-322q47 22 73.5 66t26.5 96q0 51-26.5 94.5T560-320Z"
+      />
+    </svg>
+  );
+};

--- a/src/utils/textToSpeech.ts
+++ b/src/utils/textToSpeech.ts
@@ -1,0 +1,6 @@
+export const textToSpeech = (text: string) => {
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.rate = 0.85;
+  utterance.lang = "ja-JP";
+  speechSynthesis.speak(utterance);
+};


### PR DESCRIPTION
There's now a text to speech button near the pronunciation on the word page.

<img width="372" alt="word-page" src="https://github.com/bryanjenningz/react-pleco/assets/7637655/e5a28967-201e-45d5-a652-9d1df97272ff">

There's now an text to speech button in the clip reader header when you select text.

<img width="372" alt="clip-reader-page" src="https://github.com/bryanjenningz/react-pleco/assets/7637655/14906290-b869-4e16-8e7b-22423fbe4ccb">