### PR TITLE
Make clip reader header fixed to top

### DIFF
--- a/src/components/ClipReaderHeader.tsx
+++ b/src/components/ClipReaderHeader.tsx
@@ -149,7 +149,7 @@ export const ClipReaderHeader = ({
   return (
     <header
       className={classNames(
-        "flex w-full justify-center text-white",
+        "fixed left-0 right-0 top-0 flex w-full justify-center text-white",
         isDarkMode ? "bg-black" : "bg-blue-600"
       )}
     >

--- a/src/pages/clip-reader.tsx
+++ b/src/pages/clip-reader.tsx
@@ -33,7 +33,7 @@ export default function ClipReader() {
   return (
     <main
       className={classNames(
-        "flex min-h-screen flex-col items-center",
+        "flex min-h-screen flex-col items-center pt-14",
         isDarkMode ? "bg-black text-white" : "bg-white text-black"
       )}
     >


### PR DESCRIPTION
Reason for change:
- This makes it easier to use the clip reader header when you're reading a long string of text and you scroll far down

How to test:
- Go to "/clip-reader"
- Copy/paste a long string of text
- Scroll down and verify the clip reader header is visible when text is selected and not selected

Screenshot of fixed top header when scrolled down:
<img width="390" alt="clip-reader-fixed-top-header" src="https://github.com/bryanjenningz/react-pleco/assets/7637655/3eb7bc27-c661-4584-8fc0-d6eee011ce72">

