### PR TITLE
Improve search result perceived performance on first load

### DIFF
--- a/src/dictionary/defaultSearchResults.ts
+++ b/src/dictionary/defaultSearchResults.ts
@@ -1,0 +1,179 @@
+export const DEFAULT_SEARCH_RESULTS = {
+  selectedTextLength: 7,
+  wordEntries: [
+    {
+      word: "ローマ字",
+      pronunciation: "ローマじ",
+      definitions: [
+        "(n) (1) Latin alphabet",
+        "Roman alphabet",
+        "(n) (2) romaji",
+        "romanized Japanese",
+        "system of transliterating Japanese into the Latin alphabet",
+        "(P)",
+      ],
+      pitchAccents: [3, 0],
+    },
+    {
+      word: "羅馬字",
+      pronunciation: "ローマじ",
+      definitions: [
+        "(ateji) (rK) (n) (1) Latin alphabet",
+        "Roman alphabet",
+        "(n) (2) romaji",
+        "romanized Japanese",
+        "system of transliterating Japanese into the Latin alphabet",
+      ],
+      pitchAccents: [],
+    },
+    {
+      word: "羅馬",
+      pronunciation: "ローマ",
+      definitions: ["(ateji) (rK) (n) (uk) Rome"],
+      pitchAccents: [],
+    },
+    {
+      word: "ＲＡＷ",
+      pronunciation: "ロー",
+      definitions: ["(n) raw (image format)", "RAW"],
+      pitchAccents: [],
+    },
+    {
+      word: "ろー",
+      pronunciation: "",
+      definitions: [
+        "(n) (1) (abbr) six",
+        "(exp) (2) (col) (abbr) right?",
+        "isn't it?",
+      ],
+      pitchAccents: [],
+    },
+    {
+      word: "ロー",
+      pronunciation: "",
+      definitions: ["(adj-f) (1) low", "(n) (2) low gear", "(P)"],
+      pitchAccents: [1],
+    },
+    {
+      word: "ロー",
+      pronunciation: "",
+      definitions: ["(n) law"],
+      pitchAccents: [1],
+    },
+    {
+      word: "ロー",
+      pronunciation: "",
+      definitions: ["(n) row"],
+      pitchAccents: [1],
+    },
+    {
+      word: "Ρ",
+      pronunciation: "ロー",
+      definitions: ["(n) rho"],
+      pitchAccents: [],
+    },
+    {
+      word: "ρ",
+      pronunciation: "ロー",
+      definitions: ["(n) rho"],
+      pitchAccents: [1],
+    },
+    {
+      word: "ろ",
+      pronunciation: "",
+      definitions: [
+        "(n) (1) (abbr) six",
+        "(exp) (2) (col) (abbr) right?",
+        "isn't it?",
+      ],
+      pitchAccents: [],
+    },
+    {
+      word: "ロ",
+      pronunciation: "",
+      definitions: [
+        "(n) (1) 2nd (in a sequence denoted by the iroha system)",
+        "(n) (2) (music) B (note)",
+      ],
+      pitchAccents: [1],
+    },
+    {
+      word: "ロ",
+      pronunciation: "",
+      definitions: ["(n) (abbr) Russia"],
+      pitchAccents: [1],
+    },
+    {
+      word: "魯",
+      pronunciation: "ろ",
+      definitions: [
+        "(n) Lu (Chinese vassal state existing during the Spring and Autumn period)",
+      ],
+      pitchAccents: [],
+    },
+    {
+      word: "魯",
+      pronunciation: "ろ",
+      definitions: ["(oK) (n) (abbr) Russia"],
+      pitchAccents: [],
+    },
+    {
+      word: "櫓",
+      pronunciation: "ろ",
+      definitions: [
+        "(n) Japanese scull (oar attached to the rear of the boat by a traditional peg-in-hole oarlock)",
+      ],
+      pitchAccents: [0],
+    },
+    {
+      word: "炉",
+      pronunciation: "ろ",
+      definitions: ["(n) (1) hearth", "fireplace", "(n) (2) furnace", "kiln"],
+      pitchAccents: [0],
+    },
+    {
+      word: "露",
+      pronunciation: "ろ",
+      definitions: ["(n) (abbr) Russia"],
+      pitchAccents: [1],
+    },
+    {
+      word: "廬",
+      pronunciation: "ろ",
+      definitions: ["(n) (rare) small house", "thatched hut"],
+      pitchAccents: [],
+    },
+    {
+      word: "絽",
+      pronunciation: "ろ",
+      definitions: [
+        "(n,adj-no) silk gauze (esp. used in light clothing for high summer)",
+      ],
+      pitchAccents: [0],
+    },
+    {
+      word: "艪",
+      pronunciation: "ろ",
+      definitions: [
+        "(n) Japanese scull (oar attached to the rear of the boat by a traditional peg-in-hole oarlock)",
+      ],
+      pitchAccents: [0],
+    },
+    {
+      word: "艫",
+      pronunciation: "ろ",
+      definitions: [
+        "(n) (1) stern (of a ship)",
+        "(n) (2) bow (of a ship)",
+        "prow",
+      ],
+      pitchAccents: [],
+    },
+    {
+      word: "驢",
+      pronunciation: "ろ",
+      definitions: ["(n) donkey"],
+      pitchAccents: [1],
+    },
+  ],
+};

--- a/src/dictionary/search.ts
+++ b/src/dictionary/search.ts
@@ -2,6 +2,8 @@ import { type DeinflectionRuleGroup, deinflect } from "~/dictionary/deinflect";
 import { getPitchAccents } from "~/dictionary/getPitchAccents";
 import { katakanaToHiragana } from "~/dictionary/katakanaToHiragana";
 import { romajiToHiragana } from "~/dictionary/romajiToHiragana";
+import { DEFAULT_SEARCH_TEXT } from "~/stores/searchTextStore";
+import { DEFAULT_SEARCH_RESULTS } from "~/dictionary/defaultSearchResults";
 
 export type WordEntry = {
   word: string;
@@ -23,6 +25,9 @@ export const searchWord = (
   pitchData: string[],
   text: string
 ): WordSearchResult => {
+  if (text === DEFAULT_SEARCH_TEXT) {
+    return DEFAULT_SEARCH_RESULTS;
+  }
   const wordEntries: WordEntry[] = [];
   const searchedWords = new Set<string>();
   let selectedTextLength = 1;

--- a/src/stores/searchTextStore.ts
+++ b/src/stores/searchTextStore.ts
@@ -6,10 +6,12 @@ export type SearchTextState = {
   setSearchText: (searchText: string) => void;
 };
 
+export const DEFAULT_SEARCH_TEXT = "ro-maji";
+
 export const useSearchTextStore = create<SearchTextState>()(
   persist(
     (set) => ({
-      searchText: "ro-maji",
+      searchText: DEFAULT_SEARCH_TEXT,
       setSearchText: (searchText: string) => set({ searchText }),
     }),
     { name: "search-text" }


### PR DESCRIPTION
Summary:

When the user first loads the page, the dictionary needs to be requested and cached.
To improve the search results load time, we can cache the default search results so that they appear immediately on load. 

Reason for change:

- Improved user perceived performance and user experience on first load.

How to test:

- Go "/"
- See improved performance on first load
