### PR TITLE
Fix search input cursor jumps

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,12 +21,12 @@ export default function Home() {
     <main
       className={classNames(
         "flex min-h-screen flex-col items-center",
-        isDarkMode ? "bg-black text-white" : "bg-white text-black"
+        isDarkMode ? "bg-black text-white" : "bg-white text-black",
       )}
     >
       <SearchHeader
         openSideMenu={() => setIsSideMenuOpen(true)}
-        searchText={searchText ?? ""}
+        searchText={searchText}
         setSearchText={setSearchText}
       />
 
@@ -44,7 +44,7 @@ export default function Home() {
 
 const useSearchText = () => {
   const router = useRouter();
-  const searchText = useStore(useSearchTextStore, (x) => x.searchText);
+  const searchText = useSearchTextStore((x) => x.searchText);
   const setSearchText = useSearchTextStore((x) => x.setSearchText);
   const addSearch_ = useHistoryStore((x) => x.addSearch);
   const addSearch = useMemo(() => debounce(addSearch_, 1000), [addSearch_]);
@@ -61,7 +61,7 @@ const useWordEntries = (searchText: string | undefined) => {
   const search = useSearch();
   const { wordEntries } = useMemo(
     () => search(searchText?.trim() ?? ""),
-    [searchText, search]
+    [searchText, search],
   );
   return wordEntries;
 };


### PR DESCRIPTION
- Before this change, when you typed in the middle of the search input text, it made the cursor jump to the end
- The reason for this is because we were using useStore which causes an extra rerender each time the search text changes (adding the recently typed character, then removing it, then adding it again after useStore causes a rerender), which causes the browser to make the cursor jump to the end since the value got updated by the useStore code rather than directly through the user typing
- We can fix this problem by not using useStore for the search text state, this is safe to do because the search text is not rendered in the JSX in any spot other than the input value so server and client state values don't need to match for Next.js's hydration to be successful