### PR TITLE
Reduce first load JS by 35KB on all pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,23 @@ const config = {
     locales: ["en"],
     defaultLocale: "en",
   },
+
+  webpack: (config, { dev, isServer }) => {
+    if (!dev && !isServer) {
+      Object.assign(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        config.resolve.alias,
+        {
+          "react/jsx-runtime.js": "preact/compat/jsx-runtime",
+          react: "preact/compat",
+          "react-dom/test-utils": "preact/test-utils",
+          "react-dom": "preact/compat",
+        },
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return config;
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.7.0",
     "next": "^13.5.4",
+    "preact": "^10.19.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "^3.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   next:
     specifier: ^13.5.4
     version: 13.5.4(react-dom@18.2.0)(react@18.2.0)
+  preact:
+    specifier: ^10.19.1
+    version: 10.19.1
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -2807,6 +2810,10 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /preact@10.19.1:
+    resolution: {integrity: sha512-ZSsUr6EFlwWH0btdXMj6+X+hJAZ1v+aUzKlfwBGokKB1ZO6Shz+D16LxQhM8f+E/UgkKbVe2tsWXtGTUMCkGpQ==}
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}


### PR DESCRIPTION
Here's the generated first load JS from running pnpm build

Before
```
Route (pages)                              Size     First Load JS
┌ ○ /                                      1.75 kB        96.3 kB
├   /_app                                  0 B            80.2 kB
├ ○ /404                                   182 B          80.4 kB
├ ○ /clip-reader                           4.13 kB        98.7 kB
├ ○ /clip-reader-history                   2.46 kB        85.3 kB
├ ○ /flashcard-test                        3.52 kB        93.7 kB
├ ○ /history                               3.69 kB        93.9 kB
├ ○ /new-flashcard-test                    1.26 kB        91.5 kB
├ ○ /settings                              946 B          91.2 kB
└ ○ /word                                  3.13 kB        90.3 kB
+ First Load JS shared by all              83.4 kB
  ├ chunks/framework-a4b9f4216022cc2d.js   45.3 kB
  ├ chunks/main-54de7d5857bdde45.js        33.5 kB
  ├ chunks/pages/_app-7f0f47bebfcaf94e.js  608 B
  ├ chunks/webpack-fd8027ecb5121007.js     770 B
  └ css/b9a6d5d60a23448b.css               3.25 kB

○  (Static)  automatically rendered as static HTML (uses no initial props)
```

After
```
Route (pages)                              Size     First Load JS
┌ ○ /                                      1.75 kB        60.6 kB
├   /_app                                  0 B            44.5 kB
├ ○ /404                                   179 B          44.7 kB
├ ○ /clip-reader                           4.12 kB          63 kB
├ ○ /clip-reader-history                   2.45 kB        49.7 kB
├ ○ /flashcard-test                        3.5 kB         58.1 kB
├ ○ /history                               3.68 kB        58.3 kB
├ ○ /new-flashcard-test                    1.25 kB        55.8 kB
├ ○ /settings                              944 B          55.5 kB
└ ○ /word                                  3.13 kB        54.7 kB
+ First Load JS shared by all              47.8 kB
  ├ chunks/main-d314cde48ed8607d.js        42.9 kB
  ├ chunks/pages/_app-064cae6e74b6cd65.js  825 B
  ├ chunks/webpack-fd8027ecb5121007.js     770 B
  └ css/b9a6d5d60a23448b.css               3.25 kB

○  (Static)  automatically rendered as static HTML (uses no initial props)
```