### PR TITLE
Add tutorial page

### DIFF
--- a/src/components/ClipReaderHeader.tsx
+++ b/src/components/ClipReaderHeader.tsx
@@ -21,7 +21,11 @@ const UnselectedTextMenu = ({ openSideMenu }: { openSideMenu: () => void }) => {
 
   return (
     <section className="flex h-14 items-center">
-      <button className="h-full px-4" onClick={openSideMenu}>
+      <button
+        id="side-menu-button"
+        className="h-full px-4"
+        onClick={openSideMenu}
+      >
         <span className="sr-only">Open side menu</span>
         <MenuIcon />
       </button>
@@ -31,6 +35,7 @@ const UnselectedTextMenu = ({ openSideMenu }: { openSideMenu: () => void }) => {
       </div>
 
       <button
+        id="clip-reader-paste-button"
         className="flex h-full items-center justify-center px-4"
         onClick={() => {
           void (async () => {

--- a/src/components/SearchHeader.tsx
+++ b/src/components/SearchHeader.tsx
@@ -28,7 +28,11 @@ export const SearchHeader = ({
     >
       <div className="w-full max-w-2xl">
         <section className="flex h-14 items-center pr-4">
-          <button className="h-full px-4" onClick={openSideMenu}>
+          <button
+            id="side-menu-button"
+            className="h-full px-4"
+            onClick={openSideMenu}
+          >
             <span className="sr-only">Open side menu</span>
             <MenuIcon />
           </button>

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -16,7 +16,7 @@ export const SearchResults = ({
   const isDarkMode = useStore(useDarkModeStore, (x) => x.isDarkMode) ?? true;
 
   return (
-    <ul>
+    <ul id="search-results">
       {wordEntries.map((wordEntry, resultIndex) => {
         const { word, pronunciation, pitchAccents, definitions } = wordEntry;
         const key = `${word}-${pronunciation}-${resultIndex}}`;

--- a/src/components/SelectableReadingText.tsx
+++ b/src/components/SelectableReadingText.tsx
@@ -43,6 +43,7 @@ export const SelectableReadingText = ({
 
   return (
     <p
+      id="clip-reader-text"
       className="grow p-4 pb-48 text-2xl"
       ref={paragraphRef}
       onClick={(e) => {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -14,6 +14,7 @@ import { useFlashcardStore } from "~/stores/flashcardStore";
 import { useStore } from "~/stores/useStore";
 import { classNames } from "~/utils/classNames";
 import { Modal } from "~/components/Modal";
+import { SmallLocalLibraryIcon } from "~/icons/SmallLocalLibraryIcon";
 
 type SideMenuOptionGroup = {
   label: string;
@@ -53,7 +54,15 @@ export const SideMenu = ({
     {
       label: "Dictionary",
       options: [
-        { label: "Dictionary", icon: <SmallSearchIcon />, href: "/" },
+        {
+          label: "Dictionary",
+          icon: (
+            <span id="home-link">
+              <SmallSearchIcon />
+            </span>
+          ),
+          href: "/",
+        },
         { label: "History", icon: <SmallHistoryIcon />, href: "/history" },
       ],
     },
@@ -62,7 +71,11 @@ export const SideMenu = ({
       options: [
         {
           label: "Clip Reader",
-          icon: <SmallClipboardIcon />,
+          icon: (
+            <span id="clip-reader-link">
+              <SmallClipboardIcon />
+            </span>
+          ),
           href: "/clip-reader",
         },
       ],
@@ -81,7 +94,11 @@ export const SideMenu = ({
           : []),
         {
           label: "New Test",
-          icon: <SmallLearnIcon />,
+          icon: (
+            <span id="new-flashcard-test-link">
+              <SmallLearnIcon />
+            </span>
+          ),
           href: "/new-flashcard-test",
           onClick: hasFlashcardTest
             ? (event: MouseEvent) => {
@@ -96,6 +113,16 @@ export const SideMenu = ({
       label: "Settings",
       options: [
         { label: "Settings", icon: <SmallSettingsIcon />, href: "/settings" },
+      ],
+    },
+    {
+      label: "Other",
+      options: [
+        {
+          label: "Tutorial (Beta)",
+          icon: <SmallLocalLibraryIcon />,
+          href: "/tutorial",
+        },
       ],
     },
   ];

--- a/src/components/SimpleHeader.tsx
+++ b/src/components/SimpleHeader.tsx
@@ -19,7 +19,11 @@ export const SimpleHeader = ({
     >
       <div className="w-full max-w-2xl">
         <section className="flex h-14 items-center">
-          <button className="h-full px-4" onClick={openSideMenu}>
+          <button
+            id="side-menu-button"
+            className="h-full px-4"
+            onClick={openSideMenu}
+          >
             <span className="sr-only">Open side menu</span>
             <MenuIcon />
           </button>

--- a/src/components/WordHeader.tsx
+++ b/src/components/WordHeader.tsx
@@ -43,7 +43,11 @@ export const WordHeader = ({
       >
         <div className="w-full max-w-2xl">
           <section className="flex h-14 items-center">
-            <button className="h-full px-4" onClick={() => router.back()}>
+            <button
+              id="back-button"
+              className="h-full px-4"
+              onClick={() => router.back()}
+            >
               <span className="sr-only">Go back</span>
               <ArrowBackIcon />
             </button>
@@ -52,6 +56,7 @@ export const WordHeader = ({
 
             {wordEntryIsFlashcard ? (
               <button
+                id="save-flashcard"
                 className="h-full px-4"
                 onClick={() => deleteFlashcard(wordLookup)}
               >
@@ -60,6 +65,7 @@ export const WordHeader = ({
               </button>
             ) : (
               <button
+                id="save-flashcard"
                 className="h-full px-4"
                 onClick={() => saveFlashcard(wordLookup)}
               >

--- a/src/dictionary/defaultSearchResults.ts
+++ b/src/dictionary/defaultSearchResults.ts
@@ -1,19 +1,23 @@
-export const DEFAULT_SEARCH_RESULTS = {
+import { type WordSearchResult, type WordEntry } from "~/dictionary/search";
+
+export const DEFAULT_SEARCH_RESULTS_FIRST_WORD_ENTRY: WordEntry = {
+  word: "ローマ字",
+  pronunciation: "ローマじ",
+  definitions: [
+    "(n) (1) Latin alphabet",
+    "Roman alphabet",
+    "(n) (2) romaji",
+    "romanized Japanese",
+    "system of transliterating Japanese into the Latin alphabet",
+    "(P)",
+  ],
+  pitchAccents: [3, 0],
+};
+
+export const DEFAULT_SEARCH_RESULTS: WordSearchResult = {
   selectedTextLength: 7,
   wordEntries: [
-    {
-      word: "ローマ字",
-      pronunciation: "ローマじ",
-      definitions: [
-        "(n) (1) Latin alphabet",
-        "Roman alphabet",
-        "(n) (2) romaji",
-        "romanized Japanese",
-        "system of transliterating Japanese into the Latin alphabet",
-        "(P)",
-      ],
-      pitchAccents: [3, 0],
-    },
+    DEFAULT_SEARCH_RESULTS_FIRST_WORD_ENTRY,
     {
       word: "羅馬字",
       pronunciation: "ローマじ",

--- a/src/icons/SmallLocalLibraryIcon.tsx
+++ b/src/icons/SmallLocalLibraryIcon.tsx
@@ -1,0 +1,15 @@
+export const SmallLocalLibraryIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="20"
+      viewBox="0 -960 960 960"
+      width="20"
+    >
+      <path
+        fill="currentColor"
+        d="M480-72q-69-64-155-104t-181-40v-384q95 0 179.5 39T480-456q72-66 156.5-105T816-600v384q-95 0-181 40T480-72Zm0-480q-70 0-119-49t-49-119q0-70 49-119t119-49q70 0 119 49t49 119q0 70-49 119t-119 49Z"
+      />
+    </svg>
+  );
+};

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -7,6 +7,8 @@ import NewFlashcardTest from "~/pages/new-flashcard-test";
 import ClipReader from "~/pages/clip-reader";
 import { createWordLink } from "~/utils/createWordLink";
 
+const TUTORIAL_BUTTON_WIDTH = 40;
+
 type TutorialStep =
   | { type: "START" }
   | {
@@ -242,7 +244,7 @@ export default function Tutorial() {
       const { x, y, width } = element.getBoundingClientRect();
       // Wait for off-screen elements like the side-menu to appear
       if (x < 0 || y < 0) return void requestAnimationFrame(setup);
-      setTutorialButtonXY({ x: x + width / 2 - 20, y });
+      setTutorialButtonXY({ x: x + width / 2 - TUTORIAL_BUTTON_WIDTH / 2, y });
     },
     [tutorialStep],
   );
@@ -295,8 +297,8 @@ export default function Tutorial() {
                   ? {
                       left: tutorialButtonXY.x,
                       top: tutorialButtonXY.y,
-                      width: 40,
-                      height: 40,
+                      width: TUTORIAL_BUTTON_WIDTH,
+                      height: TUTORIAL_BUTTON_WIDTH,
                     }
                   : { display: "none" }
               }

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -35,10 +35,11 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "search-input",
         instructions: 'Search for Japanese words like "ro-maji" or "ringo"',
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("search-input");
-          if (!element || !(element instanceof HTMLInputElement)) return;
-          element.focus();
+          if (!element || !(element instanceof HTMLInputElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           element.value = "ro-maji";
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
@@ -48,11 +49,15 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "search-results",
         instructions: "Click on search results to see their definition",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("search-results");
-          if (!element) return;
+          if (!element) {
+            return void requestAnimationFrame(onClick);
+          }
           const firstLink = element.querySelector("a");
-          if (!firstLink || !(firstLink instanceof HTMLAnchorElement)) return;
+          if (!firstLink) {
+            return void requestAnimationFrame(onClick);
+          }
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           void router.replace(
@@ -68,9 +73,11 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "save-flashcard",
         instructions: "Click to save the word as a flashcard to review later",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("save-flashcard");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
         },
@@ -79,9 +86,11 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "back-button",
         instructions: "Click the back button to go back",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("back-button");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           setTutorialPage("HOME");
@@ -92,9 +101,11 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "side-menu-button",
         instructions: "Click on the menu button to see the menu",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("side-menu-button");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           element.click();
@@ -116,16 +127,19 @@ export default function Tutorial() {
         nodeId: "clip-reader-paste-button",
         instructions:
           "Click the clip board refresh button to paste Japanese text from your clipboard",
-        onClick: () => {
+        onClick: function onClick() {
+          const tutorialExampleText =
+            "今季限りでヤクルトを戦力外となった松本友内野手（２８）が、警察官になるため試験を受けることが１８日、分かった。ＮＰＢでの現役続行は断念し、２０２４年１月に予定されている警視庁の採用試験を受けることを決断した。";
           void navigator.clipboard
-            .writeText(
-              "今季限りでヤクルトを戦力外となった松本友内野手（２８）が、警察官になるため試験を受けることが１８日、分かった。ＮＰＢでの現役続行は断念し、２０２４年１月に予定されている警視庁の採用試験を受けることを決断した。",
-            )
+            .writeText(tutorialExampleText)
             .finally(() => {
               const element = document.getElementById(
                 "clip-reader-paste-button",
               );
-              element?.click();
+              if (!element || !(element instanceof HTMLButtonElement)) {
+                return void requestAnimationFrame(onClick);
+              }
+              element.click();
               setTutorialIndex((x) => x + 1);
               setTutorialButtonXY(null);
             });
@@ -135,9 +149,11 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "clip-reader-text",
         instructions: "Click on Japanese text to look it up",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.querySelector("#clip-reader-text button");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           requestAnimationFrame(() => element.click());
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
@@ -148,9 +164,11 @@ export default function Tutorial() {
         nodeId: "clip-reader-text",
         instructions:
           "Here you can copy, listen, save, search, and view each word lookup. Click away to hide the lookup panel.",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.querySelector("#clip-reader-text button");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           element.click();
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
@@ -186,9 +204,11 @@ export default function Tutorial() {
         nodeId: "side-menu-button",
         instructions:
           "You can start a flashcard test once you have saved flashcards, now click the menu button",
-        onClick: () => {
+        onClick: function onClick() {
           const element = document.getElementById("side-menu-button");
-          if (!element || !(element instanceof HTMLButtonElement)) return;
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           element.click();
@@ -214,6 +234,7 @@ export default function Tutorial() {
 
   useEffect(
     function setup() {
+      window.scrollTo(0, 0);
       if (!tutorialStep || tutorialStep.type !== "CLICK") return;
       const element = document.getElementById(tutorialStep.nodeId);
       // Wait for hidden elements to appear

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -6,6 +6,7 @@ import Word from "~/pages/word";
 import NewFlashcardTest from "~/pages/new-flashcard-test";
 import ClipReader from "~/pages/clip-reader";
 import { createWordLink } from "~/utils/createWordLink";
+import { useClipReaderTextStore } from "~/stores/clipReaderTextStore";
 
 const TUTORIAL_BUTTON_WIDTH = 40;
 
@@ -29,6 +30,7 @@ export default function Tutorial() {
     x: number;
     y: number;
   }>(null);
+  const addClipReaderText = useClipReaderTextStore((x) => x.addClipReaderText);
 
   const tutorialSteps: TutorialStep[] = useMemo(
     () => [
@@ -132,19 +134,9 @@ export default function Tutorial() {
         onClick: function onClick() {
           const tutorialExampleText =
             "今季限りでヤクルトを戦力外となった松本友内野手（２８）が、警察官になるため試験を受けることが１８日、分かった。ＮＰＢでの現役続行は断念し、２０２４年１月に予定されている警視庁の採用試験を受けることを決断した。";
-          void navigator.clipboard
-            .writeText(tutorialExampleText)
-            .finally(() => {
-              const element = document.getElementById(
-                "clip-reader-paste-button",
-              );
-              if (!element || !(element instanceof HTMLButtonElement)) {
-                return void requestAnimationFrame(onClick);
-              }
-              element.click();
-              setTutorialIndex((x) => x + 1);
-              setTutorialButtonXY(null);
-            });
+          addClipReaderText({ time: Date.now(), text: tutorialExampleText });
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
         },
       },
       {
@@ -229,7 +221,7 @@ export default function Tutorial() {
       },
       { type: "FINISH" },
     ],
-    [router],
+    [router, addClipReaderText],
   );
 
   const tutorialStep = tutorialSteps[tutorialIndex];

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -275,8 +275,8 @@ export default function Tutorial() {
       case "CLICK": {
         return (
           <>
-            <p className="fixed inset-0 z-50 flex flex-col justify-end gap-4 bg-gradient-to-b from-transparent to-black p-4 text-center text-2xl text-white">
-              {tutorialStep.instructions}
+            <div className="fixed inset-0 z-50 flex flex-col justify-end gap-4 bg-gradient-to-b from-transparent to-black p-4 text-center text-2xl text-white">
+              <p>{tutorialStep.instructions}</p>
 
               <div className="h-5 w-full overflow-hidden rounded-full bg-slate-800">
                 <div
@@ -286,7 +286,7 @@ export default function Tutorial() {
                   }}
                 ></div>
               </div>
-            </p>
+            </div>
 
             <button
               className="fixed z-50 animate-ping rounded-full bg-blue-700 text-xs text-white"

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -7,8 +7,10 @@ import NewFlashcardTest from "~/pages/new-flashcard-test";
 import ClipReader from "~/pages/clip-reader";
 import { createWordLink } from "~/utils/createWordLink";
 import { useClipReaderTextStore } from "~/stores/clipReaderTextStore";
+import { useSearchTextStore } from "~/stores/searchTextStore";
 
 const TUTORIAL_BUTTON_WIDTH = 40;
+const TUTORIAL_SEARCH_TEXT = "ro-maji";
 
 type TutorialStep =
   | { type: "START" }
@@ -30,6 +32,7 @@ export default function Tutorial() {
     x: number;
     y: number;
   }>(null);
+  const setSearchText = useSearchTextStore((x) => x.setSearchText);
   const addClipReaderText = useClipReaderTextStore((x) => x.addClipReaderText);
 
   const tutorialSteps: TutorialStep[] = useMemo(
@@ -40,11 +43,7 @@ export default function Tutorial() {
         nodeId: "search-input",
         instructions: 'Search for Japanese words like "ro-maji" or "ringo"',
         onClick: function onClick() {
-          const element = document.getElementById("search-input");
-          if (!element || !(element instanceof HTMLInputElement)) {
-            return void requestAnimationFrame(onClick);
-          }
-          element.value = "ro-maji";
+          setSearchText(TUTORIAL_SEARCH_TEXT);
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
         },
@@ -57,10 +56,10 @@ export default function Tutorial() {
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           void router.replace(
-            createWordLink({ searchText: "ro-maji", resultIndex: 0 }).replace(
-              "word",
-              "tutorial",
-            ),
+            createWordLink({
+              searchText: TUTORIAL_SEARCH_TEXT,
+              resultIndex: 0,
+            }).replace("word", "tutorial"),
           );
           setTutorialPage("WORD");
         },
@@ -205,7 +204,7 @@ export default function Tutorial() {
       },
       { type: "FINISH" },
     ],
-    [router, addClipReaderText],
+    [router, addClipReaderText, setSearchText],
   );
 
   const tutorialStep = tutorialSteps[tutorialIndex];

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -7,10 +7,14 @@ import NewFlashcardTest from "~/pages/new-flashcard-test";
 import ClipReader from "~/pages/clip-reader";
 import { createWordLink } from "~/utils/createWordLink";
 import { useClipReaderTextStore } from "~/stores/clipReaderTextStore";
-import { useSearchTextStore } from "~/stores/searchTextStore";
+import {
+  DEFAULT_SEARCH_TEXT,
+  useSearchTextStore,
+} from "~/stores/searchTextStore";
+import { useFlashcardStore } from "~/stores/flashcardStore";
+import { DEFAULT_SEARCH_RESULTS_FIRST_WORD_ENTRY } from "~/dictionary/defaultSearchResults";
 
 const TUTORIAL_BUTTON_WIDTH = 40;
-const TUTORIAL_SEARCH_TEXT = "ro-maji";
 
 type TutorialStep =
   | { type: "START" }
@@ -33,6 +37,7 @@ export default function Tutorial() {
     y: number;
   }>(null);
   const setSearchText = useSearchTextStore((x) => x.setSearchText);
+  const saveFlashcard = useFlashcardStore((x) => x.saveFlashcard);
   const addClipReaderText = useClipReaderTextStore((x) => x.addClipReaderText);
 
   const tutorialSteps: TutorialStep[] = useMemo(
@@ -41,9 +46,9 @@ export default function Tutorial() {
       {
         type: "CLICK",
         nodeId: "search-input",
-        instructions: 'Search for Japanese words like "ro-maji" or "ringo"',
+        instructions: `Search for Japanese words like "${DEFAULT_SEARCH_TEXT}"`,
         onClick: function onClick() {
-          setSearchText(TUTORIAL_SEARCH_TEXT);
+          setSearchText(DEFAULT_SEARCH_TEXT);
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
         },
@@ -57,7 +62,7 @@ export default function Tutorial() {
           setTutorialButtonXY(null);
           void router.replace(
             createWordLink({
-              searchText: TUTORIAL_SEARCH_TEXT,
+              searchText: DEFAULT_SEARCH_TEXT,
               resultIndex: 0,
             }).replace("word", "tutorial"),
           );
@@ -69,6 +74,11 @@ export default function Tutorial() {
         nodeId: "save-flashcard",
         instructions: "Click to save the word as a flashcard to review later",
         onClick: () => {
+          saveFlashcard({
+            wordEntry: DEFAULT_SEARCH_RESULTS_FIRST_WORD_ENTRY,
+            resultIndex: 0,
+            searchText: DEFAULT_SEARCH_TEXT,
+          });
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
         },
@@ -204,7 +214,7 @@ export default function Tutorial() {
       },
       { type: "FINISH" },
     ],
-    [router, addClipReaderText, setSearchText],
+    [router, addClipReaderText, setSearchText, saveFlashcard],
   );
 
   const tutorialStep = tutorialSteps[tutorialIndex];

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -275,12 +275,21 @@ export default function Tutorial() {
       case "CLICK": {
         return (
           <>
-            <p className="fixed inset-0 z-50 flex flex-col justify-end bg-gradient-to-b from-transparent to-black p-4 pb-20 text-center text-2xl text-white">
+            <p className="fixed inset-0 z-50 flex flex-col justify-end gap-4 bg-gradient-to-b from-transparent to-black p-4 text-center text-2xl text-white">
               {tutorialStep.instructions}
+
+              <div className="h-5 w-full overflow-hidden rounded-full bg-slate-800">
+                <div
+                  className="h-full bg-blue-700"
+                  style={{
+                    width: `${(tutorialIndex / tutorialSteps.length) * 100}%`,
+                  }}
+                ></div>
+              </div>
             </p>
 
             <button
-              className="fixed z-50 animate-ping rounded-full bg-blue-600 text-xs text-white"
+              className="fixed z-50 animate-ping rounded-full bg-blue-700 text-xs text-white"
               style={
                 tutorialButtonXY
                   ? {

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -1,0 +1,326 @@
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+import { Dynamic } from "~/components/Dynamic";
+import Home from "~/pages/index";
+import Word from "~/pages/word";
+import NewFlashcardTest from "~/pages/new-flashcard-test";
+import ClipReader from "~/pages/clip-reader";
+import { createWordLink } from "~/utils/createWordLink";
+
+type TutorialStep =
+  | { type: "START" }
+  | {
+      type: "CLICK";
+      nodeId: string;
+      instructions: string;
+      onClick: () => void;
+    }
+  | { type: "FINISH" };
+
+type TutorialPage = "HOME" | "WORD" | "CLIP_READER" | "FLASHCARD_TEST";
+
+export default function Tutorial() {
+  const router = useRouter();
+  const [tutorialPage, setTutorialPage] = useState<TutorialPage>("HOME");
+  const [tutorialIndex, setTutorialIndex] = useState(0);
+  const [tutorialButtonXY, setTutorialButtonXY] = useState<null | {
+    x: number;
+    y: number;
+  }>(null);
+
+  const tutorialSteps: TutorialStep[] = useMemo(
+    () => [
+      { type: "START" },
+      {
+        type: "CLICK",
+        nodeId: "search-input",
+        instructions: 'Search for Japanese words like "ro-maji" or "ringo"',
+        onClick: () => {
+          const element = document.getElementById("search-input");
+          if (!element || !(element instanceof HTMLInputElement)) return;
+          element.focus();
+          element.value = "ro-maji";
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "search-results",
+        instructions: "Click on search results to see their definition",
+        onClick: () => {
+          const element = document.getElementById("search-results");
+          if (!element) return;
+          const firstLink = element.querySelector("a");
+          if (!firstLink || !(firstLink instanceof HTMLAnchorElement)) return;
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          void router.replace(
+            createWordLink({ searchText: "ro-maji", resultIndex: 0 }).replace(
+              "word",
+              "tutorial",
+            ),
+          );
+          setTutorialPage("WORD");
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "save-flashcard",
+        instructions: "Click to save the word as a flashcard to review later",
+        onClick: () => {
+          const element = document.getElementById("save-flashcard");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "back-button",
+        instructions: "Click the back button to go back",
+        onClick: () => {
+          const element = document.getElementById("back-button");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          setTutorialPage("HOME");
+          void router.replace("/tutorial");
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "side-menu-button",
+        instructions: "Click on the menu button to see the menu",
+        onClick: () => {
+          const element = document.getElementById("side-menu-button");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          element.click();
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "clip-reader-link",
+        instructions:
+          "Click the clip reader link to read Japanese text from your clipboard",
+        onClick: () => {
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          setTutorialPage("CLIP_READER");
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "clip-reader-paste-button",
+        instructions:
+          "Click the clip board refresh button to paste Japanese text from your clipboard",
+        onClick: () => {
+          void navigator.clipboard
+            .writeText(
+              "今季限りでヤクルトを戦力外となった松本友内野手（２８）が、警察官になるため試験を受けることが１８日、分かった。ＮＰＢでの現役続行は断念し、２０２４年１月に予定されている警視庁の採用試験を受けることを決断した。",
+            )
+            .finally(() => {
+              const element = document.getElementById(
+                "clip-reader-paste-button",
+              );
+              element?.click();
+              setTutorialIndex((x) => x + 1);
+              setTutorialButtonXY(null);
+            });
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "clip-reader-text",
+        instructions: "Click on Japanese text to look it up",
+        onClick: () => {
+          const element = document.querySelector("#clip-reader-text button");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          requestAnimationFrame(() => element.click());
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "clip-reader-text",
+        instructions:
+          "Here you can copy, listen, save, search, and view each word lookup. Click away to hide the lookup panel.",
+        onClick: () => {
+          const element = document.querySelector("#clip-reader-text button");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          element.click();
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "side-menu-button",
+        instructions: "Click on the menu button to see the menu",
+        onClick: function onClick() {
+          const element = document.getElementById("side-menu-button");
+          if (!element || !(element instanceof HTMLButtonElement)) {
+            return void requestAnimationFrame(onClick);
+          }
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          element.click();
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "new-flashcard-test-link",
+        instructions:
+          "You can start a new flashcard test to test your knowledge of your saved flashcards",
+        onClick: () => {
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          setTutorialPage("FLASHCARD_TEST");
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "side-menu-button",
+        instructions:
+          "You can start a flashcard test once you have saved flashcards, now click the menu button",
+        onClick: () => {
+          const element = document.getElementById("side-menu-button");
+          if (!element || !(element instanceof HTMLButtonElement)) return;
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          element.click();
+        },
+      },
+      {
+        type: "CLICK",
+        nodeId: "home-link",
+        instructions:
+          "Now let's finish the tutorial by clicking on the dictionary link",
+        onClick: () => {
+          setTutorialIndex((x) => x + 1);
+          setTutorialButtonXY(null);
+          setTutorialPage("HOME");
+        },
+      },
+      { type: "FINISH" },
+    ],
+    [router],
+  );
+
+  const tutorialStep = tutorialSteps[tutorialIndex];
+
+  useEffect(
+    function setup() {
+      if (!tutorialStep || tutorialStep.type !== "CLICK") return;
+      const element = document.getElementById(tutorialStep.nodeId);
+      // Wait for hidden elements to appear
+      if (!element) return void requestAnimationFrame(setup);
+      const { x, y, width } = element.getBoundingClientRect();
+      // Wait for off-screen elements like the side-menu to appear
+      if (x < 0) return void requestAnimationFrame(setup);
+      setTutorialButtonXY({ x: x + width / 2 - 20, y });
+    },
+    [tutorialStep],
+  );
+
+  if (!tutorialStep) {
+    setTutorialIndex(0);
+    setTutorialButtonXY(null);
+    return <></>;
+  }
+
+  const pageContent = ((): JSX.Element => {
+    switch (tutorialPage) {
+      case "HOME": {
+        return <Home />;
+      }
+      case "WORD": {
+        return <Word />;
+      }
+      case "CLIP_READER": {
+        return <ClipReader />;
+      }
+      case "FLASHCARD_TEST": {
+        return <NewFlashcardTest />;
+      }
+    }
+  })();
+
+  const tutorialContent = ((): JSX.Element => {
+    switch (tutorialStep.type) {
+      case "CLICK": {
+        return (
+          <>
+            <p className="fixed inset-0 z-50 flex flex-col justify-end bg-gradient-to-b from-transparent to-black p-4 pb-20 text-center text-2xl text-white">
+              {tutorialStep.instructions}
+            </p>
+
+            <button
+              className="fixed z-50 animate-ping rounded-full bg-blue-600 text-xs text-white"
+              style={
+                tutorialButtonXY
+                  ? {
+                      left: tutorialButtonXY.x,
+                      top: tutorialButtonXY.y,
+                      width: 40,
+                      height: 40,
+                    }
+                  : { display: "none" }
+              }
+              onClick={tutorialStep.onClick}
+            >
+              Click
+            </button>
+          </>
+        );
+      }
+      case "START": {
+        return (
+          <>
+            <div className="fixed inset-0 z-50 bg-black opacity-75"></div>
+            <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 p-4 text-white">
+              <p className="text-center text-2xl">{`Welcome to the tutorial. We'll go over how to use this web app to learn Japanese.`}</p>
+              <button
+                className="rounded-full bg-blue-700 px-4 py-2 text-white"
+                onClick={() => {
+                  setTutorialIndex((x) => x + 1);
+                }}
+              >
+                Click to start
+              </button>
+            </div>
+          </>
+        );
+      }
+      case "FINISH": {
+        return (
+          <>
+            <div className="fixed inset-0 z-50 bg-black opacity-75"></div>
+            <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 p-4 text-white">
+              <p className="text-center text-2xl">{`Congratulations! You finished the tutorial. Now you can start learning Japanese!`}</p>
+              <button
+                className="rounded-full bg-blue-700 px-4 py-2 text-white"
+                onClick={() => {
+                  void router.replace("/");
+                }}
+              >
+                Click to finish
+              </button>
+            </div>
+          </>
+        );
+      }
+    }
+  })();
+
+  return (
+    <Dynamic>
+      {pageContent}
+
+      {tutorialContent}
+    </Dynamic>
+  );
+}

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -241,7 +241,7 @@ export default function Tutorial() {
       if (!element) return void requestAnimationFrame(setup);
       const { x, y, width } = element.getBoundingClientRect();
       // Wait for off-screen elements like the side-menu to appear
-      if (x < 0) return void requestAnimationFrame(setup);
+      if (x < 0 || y < 0) return void requestAnimationFrame(setup);
       setTutorialButtonXY({ x: x + width / 2 - 20, y });
     },
     [tutorialStep],

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -53,15 +53,7 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "search-results",
         instructions: "Click on search results to see their definition",
-        onClick: function onClick() {
-          const element = document.getElementById("search-results");
-          if (!element) {
-            return void requestAnimationFrame(onClick);
-          }
-          const firstLink = element.querySelector("a");
-          if (!firstLink) {
-            return void requestAnimationFrame(onClick);
-          }
+        onClick: () => {
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           void router.replace(
@@ -77,11 +69,7 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "save-flashcard",
         instructions: "Click to save the word as a flashcard to review later",
-        onClick: function onClick() {
-          const element = document.getElementById("save-flashcard");
-          if (!element || !(element instanceof HTMLButtonElement)) {
-            return void requestAnimationFrame(onClick);
-          }
+        onClick: () => {
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
         },
@@ -90,11 +78,7 @@ export default function Tutorial() {
         type: "CLICK",
         nodeId: "back-button",
         instructions: "Click the back button to go back",
-        onClick: function onClick() {
-          const element = document.getElementById("back-button");
-          if (!element || !(element instanceof HTMLButtonElement)) {
-            return void requestAnimationFrame(onClick);
-          }
+        onClick: () => {
           setTutorialIndex((x) => x + 1);
           setTutorialButtonXY(null);
           setTutorialPage("HOME");

--- a/src/pages/tutorial.tsx
+++ b/src/pages/tutorial.tsx
@@ -269,10 +269,10 @@ export default function Tutorial() {
       case "CLICK": {
         return (
           <>
-            <div className="fixed inset-0 z-50 flex flex-col justify-end gap-4 bg-gradient-to-b from-transparent to-black p-4 text-center text-2xl text-white">
-              <p>{tutorialStep.instructions}</p>
+            <div className="fixed inset-0 z-50 flex flex-col items-center justify-end gap-4 bg-gradient-to-b from-transparent to-black p-4 text-center text-2xl text-white">
+              <p className="w-full max-w-2xl">{tutorialStep.instructions}</p>
 
-              <div className="h-5 w-full overflow-hidden rounded-full bg-slate-800">
+              <div className="h-5 w-full max-w-2xl overflow-hidden rounded-full bg-slate-800">
                 <div
                   className="h-full bg-blue-700"
                   style={{


### PR DESCRIPTION
Adding a tutorial page will help make the web app easier to understand how to use.

The tutorial page consists of a series of steps which each have a part of the page the user clicks on along with some instructions and explanations.

The tutorial page embeds other pages within it and simulates interactive clicks by querying the DOM for specific IDs of elements we want to click.

The major advantage of this embedded page approach is that changes to the existing pages are minimal. The only changes to the existing pages we need involve adding ID attributes to certain elements so they can be queried and clicked programmatically within the tutorial.
